### PR TITLE
Change anode url

### DIFF
--- a/utils/api.ts
+++ b/utils/api.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { CREDENTIALKEYS } from './constants';
 
 const API_BASE = 'https://backend.epns.io/apis/v1';
-const API_ANODE_BASE = 'https://aa1.dev.push.org/';
+const API_ANODE_BASE = 'https://aa2.dev.push.org/';
 
 export const login = async ({ user, pass }) => {
   try {

--- a/utils/json-rpc.ts
+++ b/utils/json-rpc.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE = 'https://aa1.dev.push.org/rpc';
+const API_BASE = 'https://aa2.dev.push.org/rpc';
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
aa1 is used by all consumer apps, etc
This is to make sure scan pings the anode with no / min traffic